### PR TITLE
Fixed disappearance of the selected value in a dropdowns

### DIFF
--- a/checkbox-dropdown/widget.js
+++ b/checkbox-dropdown/widget.js
@@ -17,7 +17,8 @@ define([ "troopjs-dom/component/widget" ], function (Widget) {
 				.closest("li")
 				.toggleClass("active", active)
 				.closest("ul")
-				.prev("button")
+				.prevAll("button")
+				.last()
 				.find(".value")
 				.text(text);
 		},


### PR DESCRIPTION
This PR is fixing following issue:

On iPads when click event on an option is triggered, between dropdown `ul`  and label `button` exists some other tag:
![screen shot 2015-01-28 at 12 06 42 pm](https://cloud.githubusercontent.com/assets/5370628/5972867/7bc5337c-a858-11e4-8019-4d0b51ea256a.png)
So user can't see chosen option in the label.

_Tested on iPad, IE8+, Chrome, Firefox, Safari._